### PR TITLE
eval schema property "test"

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -282,6 +282,7 @@ Validator.implement("length", true, function (options) {
 //
 // Checks given data against a single `RegExp` using `.test` or an `Array` of `RegExp` using `.test`
 Validator.implement("test", function (options) {
+  options.value = eval(options.value||'');
   if (Object.prototype.toString.call(options.value) === "[object Array]") {
     var i = 0
     var regex


### PR DESCRIPTION
There is an instance troubles me:

```
var jsonString = '{"b":{"type":"String","test":"/21/","required":true}}';
var schema = JSON.parse(jsonString);
var validator = new Validator(schema);
validator.check({"b":"1"}); 
//error occurs...
```

This PR is for the problem.